### PR TITLE
check and show pixel formats supported by the camera and the ROS message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(camera_info_manager REQUIRED)
 find_package(cv_bridge REQUIRED)
-pkg_check_modules(libcamera REQUIRED libcamera)
+pkg_check_modules(libcamera REQUIRED libcamera>=0.1)
 
 # library with common utility functions for type conversions
 add_library(utils OBJECT

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -200,6 +200,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
     RCLCPP_INFO_STREAM(get_logger(), camera_manager);
     RCLCPP_WARN_STREAM(get_logger(),
                        "no camera selected, using default: \"" << camera->id() << "\"");
+    RCLCPP_WARN_STREAM(get_logger(), "set parameter 'camera' to silent this warning");
     break;
   case rclcpp::ParameterType::PARAMETER_INTEGER:
   {
@@ -262,6 +263,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
 
     RCLCPP_WARN_STREAM(get_logger(),
                        "no pixel format selected, using default: \"" << scfg.pixelFormat << "\"");
+    RCLCPP_WARN_STREAM(get_logger(), "set parameter 'format' to silent this warning");
   }
   else {
     // get pixel format from provided string
@@ -288,6 +290,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
     scfg.size = scfg.formats().sizes(scfg.pixelFormat).back();
     RCLCPP_WARN_STREAM(get_logger(),
                        "no dimensions selected, auto-selecting: \"" << scfg.size << "\"");
+    RCLCPP_WARN_STREAM(get_logger(), "set parameter 'width' or 'height' to silent this warning");
   }
   else {
     scfg.size = size;

--- a/src/format_mapping.cpp
+++ b/src/format_mapping.cpp
@@ -13,7 +13,7 @@ namespace ros = sensor_msgs::image_encodings;
 // see 'include/uapi/drm/drm_fourcc.h' for a full FourCC list
 
 // supported FourCC formats, without conversion
-const std::unordered_map<uint32_t, std::string> map_format_raw = {
+static const std::unordered_map<uint32_t, std::string> map_format_raw = {
   // RGB encodings
   // NOTE: Following the DRM definition, RGB formats codes are stored in little-endian order.
   {cam::R8.fourcc(), ros::MONO8},
@@ -38,7 +38,7 @@ const std::unordered_map<uint32_t, std::string> map_format_raw = {
 };
 
 // supported FourCC formats, without conversion, compressed
-const std::unordered_map<uint32_t, std::string> map_format_compressed = {
+static const std::unordered_map<uint32_t, std::string> map_format_compressed = {
   {cam::MJPEG.fourcc(), "jpeg"},
 };
 
@@ -61,4 +61,17 @@ format_type(const libcamera::PixelFormat &pixelformat)
   if (map_format_compressed.count(pixelformat.fourcc()))
     return FormatType::COMPRESSED;
   return FormatType::NONE;
+}
+
+libcamera::StreamFormats
+get_common_stream_formats(const libcamera::StreamFormats &formats)
+{
+  std::map<libcamera::PixelFormat, std::vector<libcamera::SizeRange>> common_stream_formats;
+  for (const libcamera::PixelFormat &fmt : formats.pixelformats()) {
+    if (format_type(fmt) != FormatType::NONE) {
+      common_stream_formats[fmt] = {formats.range(fmt)};
+    }
+  }
+
+  return {common_stream_formats};
 }

--- a/src/format_mapping.hpp
+++ b/src/format_mapping.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <libcamera/stream.h>
 #include <string>
 
 namespace libcamera
@@ -18,3 +19,6 @@ get_ros_encoding(const libcamera::PixelFormat &pixelformat);
 
 FormatType
 format_type(const libcamera::PixelFormat &pixelformat);
+
+libcamera::StreamFormats
+get_common_stream_formats(const libcamera::StreamFormats &formats);


### PR DESCRIPTION
The node shows a list of pixel formats when the user selects no or an incompatible pixel format. This list previously contained all pixel formats supported by the camera, regardless of their support in the ROS image message. This PR lists the pixel formats supported by the camera and the ROS image message instead to help users selecting a supported pixel format.