### PR TITLE
troubleshooting common issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ This ROS 2 node provides support for a variety of cameras via [libcamera](https:
 
 Binary packages are available via the ROS package repository for some Linux and ROS distributions (check with `rosdep resolve camera_ros`). If it's available, you can install the DEB or RPM packages via:
 ```sh
-# source ROS distribution
-source /opt/ros/humble/setup.bash
+# source a ROS distribution
+source /opt/ros/$ROS_DISTRO/setup.bash
 # DEB package
 sudo apt install ros-$ROS_DISTRO-camera-ros
 # RPM package
 sudo dnf install ros-$ROS_DISTRO-camera-ros
 ```
+
+> [!NOTE]
+> This also installs the package [`libcamera`](https://index.ros.org/r/libcamera/) as dependency. This is the bloomed version of the official upstream repo at https://git.libcamera.org/libcamera/libcamera.git and may not contain full support for all Raspberry Pi camera modules. If you need full camera module support on Raspberry Pi, you have to build the "raspberrypi" fork from https://github.com/raspberrypi/libcamera manually.
 
 
 ## Build Instructions

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 This ROS 2 node provides support for a variety of cameras via [libcamera](https://libcamera.org). Amongst others, this node supports V4L2 and [Raspberry Pi cameras](https://www.raspberrypi.com/documentation/computers/camera_software.html).
 
-## Install
 
-### Binary
+## Installation
 
 Binary packages are available via the ROS package repository for some Linux and ROS distributions (check with `rosdep resolve camera_ros`). If it's available, you can install the DEB or RPM packages via:
 ```sh
@@ -16,9 +15,10 @@ sudo apt install ros-$ROS_DISTRO-camera-ros
 sudo dnf install ros-$ROS_DISTRO-camera-ros
 ```
 
-### Source
 
-#### libcamera dependency
+## Build Instructions
+
+### libcamera dependency
 
 The `camera_ros` node depends on libcamera version 0.1 or later.
 
@@ -32,7 +32,7 @@ sudo apt install pkg-config python3-yaml python3-ply python3-jinja2 openssl liby
 sudo dnf install pkgconfig python3-yaml python3-ply python3-jinja2 openssl libyaml-devel openssl-devel libudev-devel libatomic meson
 ```
 
-#### build camera_ros
+### build camera_ros
 
 The `camera_ros` package is built in a colcon workspace. The following instructions assume that you are building libcamera from source in the colcon workspace.
 
@@ -54,6 +54,7 @@ colcon build
 
 If you installed libcamera externally, you can omit the `colcon-meson` and `libcamera` steps. Additionally, if there is a binary package and a rosdep entry for libcamera (check with `rosdep resolve libcamera`) you can also omit `--skip-keys=libcamera` and have this binary dependency resolved automatically.
 
+
 ## Launching the Node
 
 The package provides a standalone node executable:
@@ -68,6 +69,7 @@ and an example launch file for the composable node:
 ```sh
 ros2 launch camera_ros camera.launch.py
 ```
+
 
 ## Interfaces
 

--- a/README.md
+++ b/README.md
@@ -34,27 +34,32 @@ The `camera_ros` node depends on libcamera version 0.1 or later. There are diffe
     2. Install `colcon-meson` via the package manager, `sudo apt install -y python3-colcon-meson`, or pip, `pip install colcon-meson`.
 
 
-### build camera_ros
+### camera_ros
 
-The `camera_ros` package is built in a colcon workspace. The following instructions assume that you are building libcamera from source in the colcon workspace.
-
+The `camera_ros` package is built together with libcamera in a colcon workspace:
 ```sh
-# create workspace with camera_ros package
-mkdir -p ~/camera_ws/
-cd ~/camera_ws/
-git clone https://github.com/christianrauch/camera_ros.git src/camera_ros
+# create workspace
+mkdir -p ~/camera_ws/src
+cd ~/camera_ws/src
 
-# optional: build libcamera in colcon workspace
-pip install colcon-meson
-git clone https://git.libcamera.org/libcamera/libcamera.git src/libcamera
+# check out libcamera
+# Option A: official upstream
+git clone https://git.libcamera.org/libcamera/libcamera.git
+# Option B: raspberrypi fork with support for newer camera modules
+# git clone https://github.com/raspberrypi/libcamera.git
+
+# check out this camera_ros repository
+git clone https://github.com/christianrauch/camera_ros.git
 
 # resolve binary dependencies and build workspace
-source /opt/ros/humble/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd ~/camera_ws/
 rosdep install --from-paths src --ignore-src --skip-keys=libcamera
 colcon build
 ```
 
-If you installed libcamera externally, you can omit the `colcon-meson` and `libcamera` steps. Additionally, if there is a binary package and a rosdep entry for libcamera (check with `rosdep resolve libcamera`) you can also omit `--skip-keys=libcamera` and have this binary dependency resolved automatically.
+If you are using a binary distribution of libcamera, you can skip adding this to the workspace. Additionally, if you want to use the bloomed libcamera package in the ROS repos, you can also omit `--skip-keys=libcamera` and have this binary dependency resolved automatically.
+
 
 
 ## Launching the Node

--- a/README.md
+++ b/README.md
@@ -21,19 +21,18 @@ sudo dnf install ros-$ROS_DISTRO-camera-ros
 
 ## Build Instructions
 
-### libcamera dependency
+### libcamera
 
-The `camera_ros` node depends on libcamera version 0.1 or later.
+The `camera_ros` node depends on libcamera version 0.1 or later. There are different ways to install this dependency:
 
-Some Linux and ROS distributions provide binary libcamera packages. Check your package manager for `libcamera` and `rosdep resolve libcamera` to see if binary packages are available.
+- __System Package:__ Most Linux distributions provide a binary libcamera package. However, the Raspberry Pi OS uses a [custom libcamera fork](https://github.com/raspberrypi/libcamera) with additional support for newer camera modules. When using the distribution packages, you have to skip the `libcamera` rosdep key when resolving dependencies (`rosdep install [...] --skip-keys=libcamera`).
 
-If your distribution does not provide a binary libcamera package, you have to compile libcamera from source either independent of the colcon workspace according to the [official build instructions](https://libcamera.org/getting-started.html) or as part of the colcon workspace. Either way, you have to install libcamera's build dependencies manually:
-```sh
-# DEB
-sudo apt install pkg-config python3-yaml python3-ply python3-jinja2 openssl libyaml-dev libssl-dev libudev-dev libatomic1 meson
-# RPM
-sudo dnf install pkgconfig python3-yaml python3-ply python3-jinja2 openssl libyaml-devel openssl-devel libudev-devel libatomic meson
-```
+- __ROS Package:__ You can also install a newer version from the ROS repo (package `ros-$ROS_DISTRO-libcamera`). This package will be installed by default when building `camera_ros` from source and resolving the rosdep keys.
+
+- __Source:__ Finally, you can always build libcamera from source. This is currently the only option for using the "raspberrypi" fork on Ubuntu. You can build libcamera as part of the ROS workspace using `colcon-meson`. This is recommended over a system-wide installation as it avoids conflicts with the system package. You will need to install the following dependencies:
+    1. Install the libcamera build dependencies according to https://libcamera.org/getting-started.html#dependencies.
+    2. Install `colcon-meson` via the package manager, `sudo apt install -y python3-colcon-meson`, or pip, `pip install colcon-meson`.
+
 
 ### build camera_ros
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ or dynamically via the [ROS parameter API](https://docs.ros.org/en/rolling/Conce
 
 The camera stream is configured once when the node starts via the following static read-only parameters:
 
-| name              | type                  | description |
-| ----------------- | --------------------- |  ---------- |
-| `camera`          | `integer` or `string` | selects the camera by index (e.g. `0`) or by name (e.g. `/base/soc/i2c0mux/i2c@1/ov5647@36`) [default: `0`]
-| `role`            | `string`              | configures the camera with a `StreamRole` (possible choices: `raw`, `still`, `video`, `viewfinder`) [default: `viewfinder`]
-| `format`          | `string`              | a `PixelFormat` that is supported by the camera [default: auto]
-| `width`, `height` | `integer`             | desired image resolution [default: auto]
+| name              | type                  | description                                                                                                                 |
+| ----------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `camera`          | `integer` or `string` | selects the camera by index (e.g. `0`) or by name (e.g. `/base/soc/i2c0mux/i2c@1/ov5647@36`) [default: `0`]                 |
+| `role`            | `string`              | configures the camera with a `StreamRole` (possible choices: `raw`, `still`, `video`, `viewfinder`) [default: `viewfinder`] |
+| `format`          | `string`              | a `PixelFormat` that is supported by the camera [default: auto]                                                             |
+| `width`, `height` | `integer`             | desired image resolution [default: auto]                                                                                    |
 
 
 The configuration is done in the following order:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The camera stream is configured once when the node starts via the following stat
 | name              | type                  | description |
 | ----------------- | --------------------- |  ---------- |
 | `camera`          | `integer` or `string` | selects the camera by index (e.g. `0`) or by name (e.g. `/base/soc/i2c0mux/i2c@1/ov5647@36`) [default: `0`]
-| `role`            | `string`              | configures the camera with a `StreamRole` (possible choices: `raw`, `still`, `video`, `viewfinder`) [default: `video`]
+| `role`            | `string`              | configures the camera with a `StreamRole` (possible choices: `raw`, `still`, `video`, `viewfinder`) [default: `viewfinder`]
 | `format`          | `string`              | a `PixelFormat` that is supported by the camera [default: auto]
 | `width`, `height` | `integer`             | desired image resolution [default: auto]
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ros2 launch camera_ros camera.launch.py
 
 ## Interfaces
 
-The camera node interfaces are compatible with the `image_pipeline` stack. The node publishes the camera images and camera parameters and provides a service to set the camera parameters.
+The camera node interfaces are compatible with the [`image_pipeline`](https://github.com/ros-perception/image_pipeline) stack. The node publishes the camera images and camera parameters and provides a service to set the camera parameters.
 
 ### Topics
 


### PR DESCRIPTION
This cleans up the documentation a bit, adds information about the ["raspberrypi" fork of libcamera](https://github.com/raspberrypi/libcamera) and instructions for troubleshooting common issues with camera detection and buffer allocation, both specifically on the Raspberry Pi.

The documentation now mentions that the official upstream version of libcamera may not support all, and especially newer, Raspberry Pi Camera Modules. A common pitfall of Raspberry Pi users is that they use the official upstream version with newer camera modules, which then cannot be detected (#67, #72).

This repo will attempt to support the official upstream and forked versions, but users have to install the "raspberrypi" fork themselves. The documentation now makes this more clear and hopefully avoids confusions about the different libcamera versions and their supported camera modules.

Fixes #67, Fixes #72.

