### PR TITLE
add NV formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(camera_ros)
 set(CMAKE_CXX_STANDARD 17)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
   add_link_options("-Wl,-z,relro,-z,now,-z,defs")
 endif()
 

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -574,7 +574,12 @@ CameraNode::requestComplete(libcamera::Request *request)
 
       // compress to jpeg
       if (pub_image_compressed->get_subscription_count())
-        compressImageMsg(*msg_img, *msg_img_compressed, {cv::IMWRITE_JPEG_QUALITY, jpeg_quality});
+        try {
+          compressImageMsg(*msg_img, *msg_img_compressed, {cv::IMWRITE_JPEG_QUALITY, jpeg_quality});
+        }
+        catch (const cv_bridge::Exception &e) {
+          RCLCPP_ERROR_STREAM(get_logger(), e.what());
+        }
     }
     else if (format_type(cfg.pixelFormat) == FormatType::COMPRESSED) {
       // compressed image

--- a/src/format_mapping.cpp
+++ b/src/format_mapping.cpp
@@ -26,6 +26,8 @@ static const std::unordered_map<uint32_t, std::string> map_format_raw = {
   // YUV encodings
   {cam::YUYV.fourcc(), ros::YUV422_YUY2},
   {cam::UYVY.fourcc(), ros::YUV422},
+  {cam::NV21.fourcc(), ros::NV21},
+  {cam::NV24.fourcc(), ros::NV24},
   // Bayer encodings
   {cam::SRGGB8.fourcc(), ros::BAYER_RGGB8},
   {cam::SGRBG8.fourcc(), ros::BAYER_GRBG8},

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,6 +4,14 @@
 #include <libcamera/geometry.h>
 #include <string>
 
+#define MAP(T, N)                                                                                  \
+  template<>                                                                                       \
+  struct ControlTypeMap<libcamera::details::control_type<T>::value>                                \
+  {                                                                                                \
+    using type = T;                                                                                \
+  };                                                                                               \
+  typedef ControlTypeMap<libcamera::ControlType##N>::type CT##N;
+
 
 namespace std
 {
@@ -17,66 +25,12 @@ to_string(const libcamera::ControlType id);
 template<libcamera::ControlType>
 struct ControlTypeMap;
 
-template<>
-struct ControlTypeMap<libcamera::ControlTypeNone>
-{
-  using type = void;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeBool>
-{
-  using type = bool;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeByte>
-{
-  using type = uint8_t;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeInteger32>
-{
-  using type = int32_t;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeInteger64>
-{
-  using type = int64_t;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeFloat>
-{
-  using type = float;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeString>
-{
-  using type = std::string;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeRectangle>
-{
-  using type = libcamera::Rectangle;
-};
-
-template<>
-struct ControlTypeMap<libcamera::ControlTypeSize>
-{
-  using type = libcamera::Size;
-};
-
-typedef ControlTypeMap<libcamera::ControlTypeNone>::type CTNone;
-typedef ControlTypeMap<libcamera::ControlTypeBool>::type CTBool;
-typedef ControlTypeMap<libcamera::ControlTypeByte>::type CTByte;
-typedef ControlTypeMap<libcamera::ControlTypeInteger32>::type CTInteger32;
-typedef ControlTypeMap<libcamera::ControlTypeInteger64>::type CTInteger64;
-typedef ControlTypeMap<libcamera::ControlTypeFloat>::type CTFloat;
-typedef ControlTypeMap<libcamera::ControlTypeString>::type CTString;
-typedef ControlTypeMap<libcamera::ControlTypeRectangle>::type CTRectangle;
-typedef ControlTypeMap<libcamera::ControlTypeSize>::type CTSize;
+MAP(void, None);
+MAP(bool, Bool);
+MAP(uint8_t, Byte);
+MAP(int32_t, Integer32);
+MAP(int64_t, Integer64);
+MAP(float, Float);
+MAP(std::string, String);
+MAP(libcamera::Rectangle, Rectangle);
+MAP(libcamera::Size, Size);


### PR DESCRIPTION
Add formats `NV21` and `NV24`. While these formats have an equivalent ROS image encoding, they are not widely used and not fully supported by the `cv_bridge`.