### PR TITLE
fix memory leaks on destruction

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -420,6 +420,7 @@ CameraNode::~CameraNode()
   if (camera->stop())
     std::cerr << "failed to stop camera" << std::endl;
   camera->release();
+  camera.reset();
   camera_manager.stop();
   for (const auto &e : buffer_info)
     if (munmap(e.second.data, e.second.size) == -1)

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -419,6 +419,8 @@ CameraNode::~CameraNode()
   // stop camera
   if (camera->stop())
     std::cerr << "failed to stop camera" << std::endl;
+  allocator->free(stream);
+  allocator.reset();
   camera->release();
   camera.reset();
   camera_manager.stop();


### PR DESCRIPTION
This fixes memory leaks reported by AddressSanitizer and libcamera errors such as:
```
ERROR DeviceEnumerator device_enumerator.cpp:172 Removing media device /dev/media1 while still in use
```
