### PR TITLE
set parameters atomically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 project(camera_ros)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>camera_ros</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>node for libcamera supported cameras (V4L2, Raspberry Pi Camera Modules)</description>
   <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
   <license>MIT</license>

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -579,7 +579,10 @@ CameraNode::declareParameters()
   std::vector<rclcpp::Parameter> parameters_init_list;
   for (const auto &[name, value] : parameters_init)
     parameters_init_list.emplace_back(name, value);
-  set_parameters(parameters_init_list);
+  const rcl_interfaces::msg::SetParametersResult param_set_result =
+    set_parameters_atomically(parameters_init_list);
+  if (!param_set_result.successful)
+    RCLCPP_ERROR_STREAM(get_logger(), "Cannot declare parameters with default value: " << param_set_result.reason);
 }
 
 void

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -364,10 +364,6 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
   RCLCPP_INFO_STREAM(get_logger(), "camera \"" << camera->id() << "\" configured with "
                                                << scfg.toString() << " stream");
 
-  set_parameter(rclcpp::Parameter("width", int64_t(scfg.size.width)));
-  set_parameter(rclcpp::Parameter("height", int64_t(scfg.size.height)));
-  set_parameter(rclcpp::Parameter("format", scfg.pixelFormat.toString()));
-
   // format camera name for calibration file
   const libcamera::ControlList &props = camera->properties();
   std::string cname = camera->id() + '_' + scfg.size.toString();

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -422,10 +422,10 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
   }
 
   // create a processing thread per request
+  running = true;
   for (const std::unique_ptr<libcamera::Request> &request : requests) {
     request_locks[request.get()] = std::make_unique<std::mutex>();
     request_locks[request.get()]->lock();
-    running = true;
     request_threads.emplace_back(&CameraNode::process, this, request.get());
   }
 

--- a/src/parameter_conflict_check.cpp
+++ b/src/parameter_conflict_check.cpp
@@ -21,8 +21,11 @@ resolve_conflicts(const ParameterMap &parameters_default, const ParameterMap &pa
   }
 
   // apply parameter overrides
-  for (const auto &[name, value] : parameters_overrides)
-    parameters_init[name] = value;
+  for (const auto &[name, value] : parameters_overrides) {
+    // only override parameters that have matching controls
+    if (parameters_default.count(name))
+      parameters_init[name] = value;
+  }
 
   // overrides: prefer provided exposure
   if (parameters_init.count("AeEnable") && parameters_init.at("AeEnable").get<bool>() &&


### PR DESCRIPTION
This PR contains a couple of minor tweaks and prepares the 0.2 release:
- set parameters all at once to reduce the number of callback calls
- remove setting of read-only parameters
- check result of parameter callbacks
- set the `running` flag for the process threads only once for all threads