### PR TITLE
optional image view dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>image_view</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != 'humble'">image_view</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>cv_bridge</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>image_view</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>camera_ros</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>node for libcamera supported cameras (V4L2, Raspberry Pi Camera Modules)</description>
   <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
   <license>MIT</license>

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>libcamera</depend>
+  <depend version_gte="0.1">libcamera</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
The [humble build on RHEL8 fails](https://build.ros2.org/view/Hbin_rhel_el864/job/Hbin_rhel_el864__camera_ros__rhel_8_x86_64__binary/) due to an [issue with the `image_view` package](https://build.ros2.org/job/Hbin_rhel_el864__image_view__rhel_8_x86_64__binary/).

Work around this by making the runtime dependency on package `image_view` optional, and only add the `ImageViewNode` when the package is available. The commit 31e886eb35ea27f4e658d378d93ae77f4ab07976 can be reverted once support for humble is dropped.