### PR TITLE
add AlmaLinux 8 and fix warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,6 @@ jobs:
 
     container:
       image: ${{ matrix.distribution }}:${{ matrix.version }}
-      env:
-        PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
       - name: install ROS 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,25 @@ jobs:
         run: |
           dnf -y install libasan python3-mypy
 
-      - name: build and test
-        uses: ros-tooling/action-ros-ci@v0.3
+      - name: setup rosdep
+        run: |
+          rosdep update
+
+      - name: setup mixins
+        run: |
+          colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          colcon mixin update default
+
+      - uses: actions/checkout@v4
         with:
-          package-name: camera_ros
-          target-ros2-distro: ${{ matrix.ros }}
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["asan-gcc", "tsan", "coverage-gcc", "memcheck"]
-              }
-            }
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/5d51dff38097e8c2bf46d7a5b804e65935aa7f47/index.yaml
+          path: src
+
+      - name: build and test
+        run: |
+          rosdep install --from-paths src --ignore-src -y --rosdistro ${{ matrix.ros }}
+          . /opt/ros/${{ matrix.ros }}/setup.sh
+          colcon build \
+            --event-handlers=console_cohesion+ \
+            --mixin asan-gcc tsan coverage-gcc memcheck \
+            --packages-up-to camera_ros
+          colcon test --return-code-on-test-failure --event-handlers=console_cohesion+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,17 +13,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - distribution: ubuntu
-            version: 22.04
-            ros: humble
-
-          - distribution: ubuntu
-            version: 24.04
-            ros: jazzy
-
-          - distribution: almalinux
-            version: 9
-            ros: jazzy
+          - {distribution: ubuntu,    version: 22.04, ros: humble}
+          - {distribution: ubuntu,    version: 24.04, ros: jazzy}
+          - {distribution: almalinux, version: 8,     ros: humble}
+          - {distribution: almalinux, version: 9,     ros: jazzy}
 
     continue-on-error: ${{ matrix.ros == 'rolling' }}
 

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>clang-format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -25,12 +25,12 @@ to_string(const libcamera::ControlType id);
 template<libcamera::ControlType>
 struct ControlTypeMap;
 
-MAP(void, None);
-MAP(bool, Bool);
-MAP(uint8_t, Byte);
-MAP(int32_t, Integer32);
-MAP(int64_t, Integer64);
-MAP(float, Float);
-MAP(std::string, String);
-MAP(libcamera::Rectangle, Rectangle);
-MAP(libcamera::Size, Size);
+MAP(void, None)
+MAP(bool, Bool)
+MAP(uint8_t, Byte)
+MAP(int32_t, Integer32)
+MAP(int64_t, Integer64)
+MAP(float, Float)
+MAP(std::string, String)
+MAP(libcamera::Rectangle, Rectangle)
+MAP(libcamera::Size, Size)


### PR DESCRIPTION
The ROS 2 build server reported `error: extra ';' [-Werror=pedantic]` after the `MAP` macro on AlmaLinux 8. Fix this by removing the extra `;` and add AlmaLinux 8 to the CI. This requires switching from action `ros-tooling/action-ros-ci` to manual steps.