### PR TITLE
support new control types

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -70,6 +70,12 @@ namespace rclcpp
 class NodeOptions;
 }
 
+#define CASE_RANGE(T, R)                                       \
+  case libcamera::ControlType##T:                              \
+    R.from_value = max<libcamera::ControlType##T>(info.min()); \
+    R.to_value = min<libcamera::ControlType##T>(info.max());   \
+    break;
+
 
 namespace camera
 {
@@ -528,18 +534,13 @@ CameraNode::declareParameters()
     rcl_interfaces::msg::FloatingPointRange range_float;
 
     switch (id->type()) {
-    case libcamera::ControlTypeInteger32:
-      range_int.from_value = max<libcamera::ControlTypeInteger32>(info.min());
-      range_int.to_value = min<libcamera::ControlTypeInteger32>(info.max());
-      break;
-    case libcamera::ControlTypeInteger64:
-      range_int.from_value = max<libcamera::ControlTypeInteger64>(info.min());
-      range_int.to_value = min<libcamera::ControlTypeInteger64>(info.max());
-      break;
-    case libcamera::ControlTypeFloat:
-      range_float.from_value = max<libcamera::ControlTypeFloat>(info.min());
-      range_float.to_value = min<libcamera::ControlTypeFloat>(info.max());
-      break;
+      CASE_RANGE(Integer32, range_int)
+      CASE_RANGE(Integer64, range_int)
+      CASE_RANGE(Float, range_float)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+      CASE_RANGE(Unsigned16, range_int)
+      CASE_RANGE(Unsigned32, range_int)
+#endif
     default:
       break;
     }

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -270,7 +270,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
     RCLCPP_DEBUG_STREAM(get_logger(), "found camera by name: \"" << name << "\"");
   } break;
   default:
-    RCLCPP_ERROR_STREAM(get_logger(), "unuspported camera parameter type: "
+    RCLCPP_ERROR_STREAM(get_logger(), "unsupported camera parameter type: "
                                         << get_parameter("camera").get_type_name());
     break;
   }

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -331,7 +331,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
 
   const libcamera::Size size(get_parameter("width").as_int(), get_parameter("height").as_int());
   if (size.isNull()) {
-    RCLCPP_INFO_STREAM(get_logger(), scfg);
+    RCLCPP_INFO_STREAM(get_logger(), list_format_sizes(scfg));
     RCLCPP_WARN_STREAM(get_logger(),
                        "no dimensions selected, auto-selecting: \"" << scfg.size << "\"");
     RCLCPP_WARN_STREAM(get_logger(), "set parameter 'width' or 'height' to silence this warning");
@@ -350,7 +350,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
     if (selected_scfg.pixelFormat != scfg.pixelFormat)
       RCLCPP_INFO_STREAM(get_logger(), stream_formats);
     if (selected_scfg.size != scfg.size)
-      RCLCPP_INFO_STREAM(get_logger(), scfg);
+      RCLCPP_INFO_STREAM(get_logger(), list_format_sizes(scfg));
     RCLCPP_WARN_STREAM(get_logger(), "stream configuration adjusted from \""
                                        << selected_scfg.toString() << "\" to \"" << scfg.toString()
                                        << "\"");

--- a/src/clamp.cpp
+++ b/src/clamp.cpp
@@ -1,3 +1,4 @@
+#include "libcamera_version_utils.hpp"
 #include "types.hpp"
 #include <algorithm>
 #include <cassert>
@@ -66,6 +67,12 @@ MIN(Float)
 MAX(Integer32)
 MAX(Integer64)
 MAX(Float)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+MIN(Unsigned16)
+MIN(Unsigned32)
+MAX(Unsigned16)
+MAX(Unsigned32)
+#endif
 
 namespace std
 {
@@ -79,6 +86,17 @@ clamp(const CTRectangle &val, const CTRectangle &lo, const CTRectangle &hi)
 
   return CTRectangle {x, y, width, height};
 }
+
+#if LIBCAMERA_VER_GE(0, 4, 0)
+CTPoint
+clamp(const CTPoint &val, const CTPoint &lo, const CTPoint &hi)
+{
+  const int x = std::clamp(val.x, lo.x, hi.x);
+  const int y = std::clamp(val.y, lo.y, hi.y);
+
+  return CTPoint {x, y};
+}
+#endif
 } // namespace std
 
 
@@ -135,6 +153,11 @@ clamp(const libcamera::ControlValue &value, const libcamera::ControlValue &min,
     CASE_CLAMP(String)
     CASE_CLAMP(Rectangle)
     CASE_CLAMP(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_CLAMP(Unsigned16)
+    CASE_CLAMP(Unsigned32)
+    CASE_CLAMP(Point)
+#endif
   }
 
   return {};
@@ -156,6 +179,28 @@ operator>(const libcamera::Rectangle &lhs, const libcamera::Rectangle &rhs)
   return lhs.x < rhs.x && lhs.y < rhs.y && (lhs.x + lhs.width) > (rhs.x + rhs.width) &&
          (lhs.y + lhs.height) > (rhs.y + rhs.height);
 }
+
+#if LIBCAMERA_VER_GE(0, 4, 0)
+int
+squared_sum(const libcamera::Point &p)
+{
+  return p.x * p.x + p.y * p.y;
+}
+
+bool
+operator<(const libcamera::Point &lhs, const libcamera::Point &rhs)
+{
+  // check if lhs point is closer to origin than rhs point
+  return squared_sum(lhs) < squared_sum(rhs);
+}
+
+bool
+operator>(const libcamera::Point &lhs, const libcamera::Point &rhs)
+{
+  // check if lhs point is further away from origin than rhs point
+  return squared_sum(lhs) > squared_sum(rhs);
+}
+#endif
 
 template<typename T>
 bool
@@ -261,6 +306,11 @@ operator<(const libcamera::ControlValue &lhs, const libcamera::ControlValue &rhs
     CASE_LESS(String)
     CASE_LESS(Rectangle)
     CASE_LESS(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_LESS(Unsigned16)
+    CASE_LESS(Unsigned32)
+    CASE_LESS(Point)
+#endif
   }
 
   throw std::runtime_error("unhandled control type " + std::to_string(lhs.type()));
@@ -282,6 +332,11 @@ operator>(const libcamera::ControlValue &lhs, const libcamera::ControlValue &rhs
     CASE_GREATER(String)
     CASE_GREATER(Rectangle)
     CASE_GREATER(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_GREATER(Unsigned16)
+    CASE_GREATER(Unsigned32)
+    CASE_GREATER(Point)
+#endif
   }
 
   throw std::runtime_error("unhandled control type " + std::to_string(lhs.type()));

--- a/src/cv_to_pv.cpp
+++ b/src/cv_to_pv.cpp
@@ -61,6 +61,18 @@ cv_to_pv_scalar(const T &value)
 }
 
 rclcpp::ParameterValue
+cv_to_pv_scalar(const uint16_t &val)
+{
+  return rclcpp::ParameterValue(static_cast<int32_t>(val));
+}
+
+rclcpp::ParameterValue
+cv_to_pv_scalar(const uint32_t &val)
+{
+  return rclcpp::ParameterValue(static_cast<int64_t>(val));
+}
+
+rclcpp::ParameterValue
 cv_to_pv_scalar(const libcamera::Rectangle &rectangle)
 {
   return rclcpp::ParameterValue(

--- a/src/cv_to_pv.cpp
+++ b/src/cv_to_pv.cpp
@@ -35,25 +35,25 @@ extract_value(const libcamera::ControlValue &value)
 
 template<
   typename T,
-  std::enable_if_t<std::is_arithmetic<T>::value || std::is_same<std::string, T>::value, bool> = true>
+  std::enable_if_t<std::is_constructible<rclcpp::ParameterValue, std::vector<T>>::value, bool> = true>
 rclcpp::ParameterValue
 cv_to_pv_array(const std::vector<T> &values)
 {
   return rclcpp::ParameterValue(values);
 }
 
-template<typename T,
-         std::enable_if_t<!std::is_arithmetic<T>::value && !std::is_same<std::string, T>::value,
-                          bool> = true>
+template<
+  typename T,
+  std::enable_if_t<!std::is_constructible<rclcpp::ParameterValue, std::vector<T>>::value, bool> = true>
 rclcpp::ParameterValue
 cv_to_pv_array(const std::vector<T> & /*values*/)
 {
-  throw invalid_conversion("ParameterValue only supported for arithmetic types");
+  throw invalid_conversion("ParameterValue not constructible from complex type.");
 }
 
 template<
   typename T,
-  std::enable_if_t<std::is_arithmetic<T>::value || std::is_same<std::string, T>::value, bool> = true>
+  std::enable_if_t<std::is_constructible<rclcpp::ParameterValue, T>::value, bool> = true>
 rclcpp::ParameterValue
 cv_to_pv_scalar(const T &value)
 {

--- a/src/cv_to_pv.cpp
+++ b/src/cv_to_pv.cpp
@@ -1,4 +1,5 @@
 #include "cv_to_pv.hpp"
+#include "libcamera_version_utils.hpp"
 #include "type_extent.hpp"
 #include "types.hpp"
 #include <cstdint>
@@ -85,6 +86,14 @@ cv_to_pv_scalar(const libcamera::Size &size)
   return rclcpp::ParameterValue(std::vector<int64_t> {size.width, size.height});
 }
 
+#if LIBCAMERA_VER_GE(0, 4, 0)
+rclcpp::ParameterValue
+cv_to_pv_scalar(const libcamera::Point &point)
+{
+  return rclcpp::ParameterValue(std::vector<int64_t> {point.x, point.y});
+}
+#endif
+
 template<typename T>
 rclcpp::ParameterValue
 cv_to_pv(const std::vector<T> &values)
@@ -115,6 +124,11 @@ cv_to_pv(const libcamera::ControlValue &value)
     CASE_CONVERT(String)
     CASE_CONVERT(Rectangle)
     CASE_CONVERT(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_CONVERT(Unsigned16)
+    CASE_CONVERT(Unsigned32)
+    CASE_CONVERT(Point)
+#endif
   }
 
   return {};
@@ -130,6 +144,10 @@ cv_to_pv_type(const libcamera::ControlId *const id)
     case libcamera::ControlType::ControlTypeBool:
       return rclcpp::ParameterType::PARAMETER_BOOL;
     case libcamera::ControlType::ControlTypeByte:
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    case libcamera::ControlType::ControlTypeUnsigned16:
+    case libcamera::ControlType::ControlTypeUnsigned32:
+#endif
     case libcamera::ControlType::ControlTypeInteger32:
     case libcamera::ControlType::ControlTypeInteger64:
       return rclcpp::ParameterType::PARAMETER_INTEGER;
@@ -141,6 +159,10 @@ cv_to_pv_type(const libcamera::ControlId *const id)
       return rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY;
     case libcamera::ControlType::ControlTypeSize:
       return rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY;
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    case libcamera::ControlType::ControlTypePoint:
+      return rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY;
+#endif
     }
   }
   else {
@@ -150,6 +172,10 @@ cv_to_pv_type(const libcamera::ControlId *const id)
     case libcamera::ControlType::ControlTypeBool:
       return rclcpp::ParameterType::PARAMETER_BOOL_ARRAY;
     case libcamera::ControlType::ControlTypeByte:
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    case libcamera::ControlType::ControlTypeUnsigned16:
+    case libcamera::ControlType::ControlTypeUnsigned32:
+#endif
     case libcamera::ControlType::ControlTypeInteger32:
     case libcamera::ControlType::ControlTypeInteger64:
       return rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY;
@@ -161,6 +187,10 @@ cv_to_pv_type(const libcamera::ControlId *const id)
       return rclcpp::ParameterType::PARAMETER_NOT_SET;
     case libcamera::ControlType::ControlTypeSize:
       return rclcpp::ParameterType::PARAMETER_NOT_SET;
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    case libcamera::ControlType::ControlTypePoint:
+      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+#endif
     }
   }
 

--- a/src/cv_to_pv.hpp
+++ b/src/cv_to_pv.hpp
@@ -1,6 +1,6 @@
 #pragma once
+#include "exceptions.hpp"
 #include <rclcpp/parameter_value.hpp>
-#include <stdexcept>
 #include <string>
 
 namespace libcamera
@@ -8,13 +8,6 @@ namespace libcamera
 class ControlId;
 class ControlValue;
 } // namespace libcamera
-
-
-class invalid_conversion : public std::runtime_error
-{
-public:
-  explicit invalid_conversion(const std::string &msg) : std::runtime_error(msg) {}
-};
 
 
 rclcpp::ParameterValue

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -7,3 +7,9 @@ class invalid_conversion : public std::runtime_error
 public:
   explicit invalid_conversion(const std::string &msg) : std::runtime_error(msg) {}
 };
+
+class should_not_reach : public std::runtime_error
+{
+public:
+  explicit should_not_reach() : std::runtime_error("should not reach here") {}
+};

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <stdexcept>
+
+
+class invalid_conversion : public std::runtime_error
+{
+public:
+  explicit invalid_conversion(const std::string &msg) : std::runtime_error(msg) {}
+};

--- a/src/libcamera_version_utils.hpp
+++ b/src/libcamera_version_utils.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <libcamera/version.h>
+
+#define LIBCAMERA_VER_GE(major, minor, patch)                               \
+  ((major < LIBCAMERA_VERSION_MAJOR) ||                                     \
+   (major == LIBCAMERA_VERSION_MAJOR && minor < LIBCAMERA_VERSION_MINOR) || \
+   (major == LIBCAMERA_VERSION_MAJOR && minor == LIBCAMERA_VERSION_MINOR && \
+    patch <= LIBCAMERA_VERSION_PATCH))

--- a/src/pretty_print.cpp
+++ b/src/pretty_print.cpp
@@ -9,6 +9,7 @@
 #include <libcamera/stream.h>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -43,13 +44,14 @@ operator<<(std::ostream &out, const libcamera::StreamFormats &formats)
   return out;
 }
 
-std::ostream &
-operator<<(std::ostream &out, const libcamera::StreamConfiguration &configuration)
+std::string
+list_format_sizes(const libcamera::StreamConfiguration &configuration)
 {
+  std::ostringstream out;
   out << std::endl
       << ">> " << configuration.pixelFormat << " format sizes:";
   for (const libcamera::Size &size : configuration.formats().sizes(configuration.pixelFormat))
     out << std::endl
         << "   - " << size.toString();
-  return out;
+  return out.str();
 }

--- a/src/pretty_print.hpp
+++ b/src/pretty_print.hpp
@@ -15,5 +15,5 @@ operator<<(std::ostream &out, const libcamera::CameraManager &camera_manager);
 std::ostream &
 operator<<(std::ostream &out, const libcamera::StreamFormats &formats);
 
-std::ostream &
-operator<<(std::ostream &out, const libcamera::StreamConfiguration &configuration);
+std::string
+list_format_sizes(const libcamera::StreamConfiguration &configuration);

--- a/src/pv_to_cv.cpp
+++ b/src/pv_to_cv.cpp
@@ -1,4 +1,6 @@
 #include "pv_to_cv.hpp"
+#include "exceptions.hpp"
+#include "libcamera_version_utils.hpp"
 #include "types.hpp"
 #include <cstdint>
 #include <libcamera/base/span.h>
@@ -9,23 +11,50 @@
 #include <vector>
 
 
+#define CASE_CONVERT_INT(T)       \
+  case libcamera::ControlType##T: \
+    return ControlTypeMap<libcamera::ControlType##T>::type(parameter.as_int());
+
+#define CASE_CONVERT_INT_ARRAY(T) \
+  case libcamera::ControlType##T: \
+    return libcamera::Span<const ControlTypeMap<libcamera::ControlType##T>::type>(std::vector<ControlTypeMap<libcamera::ControlType##T>::type>(values.begin(), values.end()));
+
+#define CASE_NONE(T)              \
+  case libcamera::ControlType##T: \
+    return {};
+
+#define CASE_INVALID(T)           \
+  case libcamera::ControlType##T: \
+    throw invalid_conversion("cannot convert integer array to ##T");
+
+
 libcamera::ControlValue
 pv_to_cv_int_array(const std::vector<int64_t> &values, const libcamera::ControlType &type)
 {
-  // convert to Span (Integer32, Integer64) or geometric type Rectangle, Size
+  // convert to integer Span, geometric type Rectangle, Size, Point, or throw exception
   switch (type) {
-  case libcamera::ControlTypeInteger32:
-    return {
-      libcamera::Span<const CTInteger32>(std::vector<CTInteger32>(values.begin(), values.end()))};
+    CASE_NONE(None)
+    CASE_INVALID(Bool)
+    CASE_INVALID(Byte)
+    CASE_CONVERT_INT_ARRAY(Integer32)
   case libcamera::ControlTypeInteger64:
-    return {libcamera::Span<const CTInteger64>(values)};
+    return libcamera::Span<const CTInteger64>(values);
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_CONVERT_INT_ARRAY(Unsigned16)
+    CASE_CONVERT_INT_ARRAY(Unsigned32)
+#endif
+    CASE_CONVERT_INT_ARRAY(Float)
+    CASE_INVALID(String)
   case libcamera::ControlTypeRectangle:
-    return {libcamera::Rectangle(values[0], values[1], values[2], values[3])};
+    return libcamera::Rectangle(values[0], values[1], values[2], values[3]);
   case libcamera::ControlTypeSize:
-    return {libcamera::Size(values[0], values[1])};
-  default:
-    return {};
+    return libcamera::Size(values[0], values[1]);
+#if LIBCAMERA_VER_GE(0, 4, 0)
+  case libcamera::ControlTypePoint:
+    return libcamera::Point(values[0], values[1]);
+#endif
   }
+  throw should_not_reach();
 }
 
 libcamera::ControlValue
@@ -35,33 +64,41 @@ pv_to_cv(const rclcpp::Parameter &parameter, const libcamera::ControlType &type)
   case rclcpp::ParameterType::PARAMETER_NOT_SET:
     return {};
   case rclcpp::ParameterType::PARAMETER_BOOL:
-    return {parameter.as_bool()};
+    return parameter.as_bool();
   case rclcpp::ParameterType::PARAMETER_INTEGER:
-    if (type == libcamera::ControlTypeInteger32)
-      return {CTInteger32(parameter.as_int())};
-    else if (type == libcamera::ControlTypeInteger64)
-      return {CTInteger64(parameter.as_int())};
-    else
-      return {};
+    switch (type) {
+      CASE_NONE(None)
+      CASE_CONVERT_INT(Bool)
+      CASE_CONVERT_INT(Byte)
+      CASE_CONVERT_INT(Integer32)
+      CASE_CONVERT_INT(Integer64)
+      CASE_CONVERT_INT(Float)
+      CASE_NONE(String)
+      CASE_NONE(Rectangle)
+      CASE_NONE(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+      CASE_CONVERT_INT(Unsigned16)
+      CASE_CONVERT_INT(Unsigned32)
+      CASE_NONE(Point)
+#endif
+    }
+    throw should_not_reach();
   case rclcpp::ParameterType::PARAMETER_DOUBLE:
-    return {CTFloat(parameter.as_double())};
+    return CTFloat(parameter.as_double());
   case rclcpp::ParameterType::PARAMETER_STRING:
-    return {parameter.as_string()};
+    return CTString(parameter.as_string());
   case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
-    return {libcamera::Span<const CTByte>(parameter.as_byte_array())};
+    return libcamera::Span<const CTByte>(parameter.as_byte_array());
   case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
-    return {};
+    throw invalid_conversion("cannot convert bool array to control value");
   case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
     return pv_to_cv_int_array(parameter.as_integer_array(), type);
   case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
-  {
     // convert to float vector
-    return {libcamera::Span<const CTFloat>(
-      std::vector<CTFloat>(parameter.as_double_array().begin(), parameter.as_double_array().end()))};
-  }
+    return libcamera::Span<const CTFloat>(
+      std::vector<CTFloat>(parameter.as_double_array().begin(), parameter.as_double_array().end()));
   case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
-    return {libcamera::Span<const CTString>(parameter.as_string_array())};
-  default:
-    return {};
+    return libcamera::Span<const CTString>(parameter.as_string_array());
   }
+  throw should_not_reach();
 }

--- a/src/type_extent.cpp
+++ b/src/type_extent.cpp
@@ -1,18 +1,11 @@
 #include "type_extent.hpp"
+#include "libcamera_version_utils.hpp"
 #include <libcamera/base/span.h>
 #include <libcamera/control_ids.h>
 #include <libcamera/controls.h>
-#include <libcamera/version.h>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-
-
-#define LIBCAMERA_VER_GE(major, minor, patch)                               \
-  ((major < LIBCAMERA_VERSION_MAJOR) ||                                     \
-   (major == LIBCAMERA_VERSION_MAJOR && minor < LIBCAMERA_VERSION_MINOR) || \
-   (major == LIBCAMERA_VERSION_MAJOR && minor == LIBCAMERA_VERSION_MINOR && \
-    patch <= LIBCAMERA_VERSION_PATCH))
 
 
 template<typename T, std::enable_if_t<!libcamera::details::is_span<T>::value, bool> = true>

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -19,6 +19,11 @@ std::to_string(const libcamera::ControlType id)
     CASE_TYPE(String)
     CASE_TYPE(Rectangle)
     CASE_TYPE(Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+    CASE_TYPE(Unsigned16)
+    CASE_TYPE(Unsigned32)
+    CASE_TYPE(Point)
+#endif
   }
 
   return {};

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "libcamera_version_utils.hpp"
 #include <cstdint>
 #include <libcamera/controls.h>
 #include <libcamera/geometry.h>
@@ -34,3 +35,8 @@ MAP(float, Float)
 MAP(std::string, String)
 MAP(libcamera::Rectangle, Rectangle)
 MAP(libcamera::Size, Size)
+#if LIBCAMERA_VER_GE(0, 4, 0)
+MAP(uint16_t, Unsigned16)
+MAP(uint32_t, Unsigned32)
+MAP(libcamera::Point, Point)
+#endif


### PR DESCRIPTION
libcamera 0.4.0 introduces the new control types `ControlTypeUnsigned16` / `uint16_t`, `ControlTypeUnsigned32` / `uint32_t` and `ControlTypePoint` / `libcamera::Point`. Support these by new conversions and checks.