### PR TITLE
change default stream role

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -211,7 +211,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
   param_descr_role.description = "stream role";
   param_descr_role.additional_constraints = "one of {raw, still, video, viewfinder}";
   param_descr_role.read_only = true;
-  declare_parameter<std::string>("role", "video", param_descr_role);
+  declare_parameter<std::string>("role", "viewfinder", param_descr_role);
 
   // image dimensions
   rcl_interfaces::msg::ParameterDescriptor param_descr_ro;

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -365,7 +365,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
                                        << "\"");
     break;
   case libcamera::CameraConfiguration::Invalid:
-    throw std::runtime_error("failed to valid stream configurations");
+    throw std::runtime_error("failed to validate stream configurations");
     break;
   }
 

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -294,6 +294,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
   if (!cfg)
     throw std::runtime_error("failed to generate configuration");
 
+  assert(cfg->size() == 1);
   libcamera::StreamConfiguration &scfg = cfg->at(0);
   // get common pixel formats that are supported by the camera and the node
   const libcamera::StreamFormats stream_formats = get_common_stream_formats(scfg.formats());

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -288,8 +288,9 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
     throw std::runtime_error("failed to acquire camera");
 
   // configure camera stream
+  const libcamera::StreamRole role = get_role(get_parameter("role").as_string());
   std::unique_ptr<libcamera::CameraConfiguration> cfg =
-    camera->generateConfiguration({get_role(get_parameter("role").as_string())});
+    camera->generateConfiguration({role});
 
   if (!cfg)
     throw std::runtime_error("failed to generate configuration");
@@ -301,7 +302,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
   const std::vector<libcamera::PixelFormat> common_fmt = stream_formats.pixelformats();
 
   // list all camera formats, including those not supported by the ROS message
-  RCLCPP_DEBUG_STREAM(get_logger(), "default stream configuration: \"" << scfg.toString() << "\"");
+  RCLCPP_DEBUG_STREAM(get_logger(), "default " << role << " stream configuration: \"" << scfg.toString() << "\"");
   RCLCPP_DEBUG_STREAM(get_logger(), scfg.formats());
 
   if (common_fmt.empty())

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -297,13 +297,14 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options) : Node("camera", opti
 
   assert(cfg->size() == 1);
   libcamera::StreamConfiguration &scfg = cfg->at(0);
-  // get common pixel formats that are supported by the camera and the node
-  const libcamera::StreamFormats stream_formats = get_common_stream_formats(scfg.formats());
-  const std::vector<libcamera::PixelFormat> common_fmt = stream_formats.pixelformats();
 
   // list all camera formats, including those not supported by the ROS message
   RCLCPP_DEBUG_STREAM(get_logger(), "default " << role << " stream configuration: \"" << scfg.toString() << "\"");
   RCLCPP_DEBUG_STREAM(get_logger(), scfg.formats());
+
+  // get common pixel formats that are supported by the camera and the node
+  const libcamera::StreamFormats stream_formats = get_common_stream_formats(scfg.formats());
+  const std::vector<libcamera::PixelFormat> common_fmt = stream_formats.pixelformats();
 
   if (common_fmt.empty())
     throw std::runtime_error("camera does not provide any of the supported pixel formats");

--- a/src/pretty_print.cpp
+++ b/src/pretty_print.cpp
@@ -37,7 +37,7 @@ operator<<(std::ostream &out, const libcamera::StreamFormats &formats)
       << ">> stream formats:";
   for (const libcamera::PixelFormat &pixelformat : formats.pixelformats()) {
     out << std::endl
-        << "   - Pixelformat: " << pixelformat.toString() << " ("
+        << "   - " << pixelformat.toString() << " ("
         << formats.range(pixelformat).min.toString() << " - "
         << formats.range(pixelformat).max.toString() << ")";
   }


### PR DESCRIPTION
The `video` role may lead to the selection of a configuration that is adjusted automatically via `CameraConfiguration::validate()` to an invalid configuration that will cause `Camera::configure()` to fail with `-EINVAL`.

For example, with a `imx708_wide` (Camera Module 3) the initial configuration "1920x1080-R8" will be adjusted to "2304x1296-SBGGR16", even though the resolution "2304x1296" is not supported for the "SBGGR16" pixel format.

Likewise, setting the format explicitly to a listed configuration (`-p format:=SBGGR16 -p width:=1536 -p height:=864`) will adjust the configuration from "1536x864-SBGGR16" to "1536x864-SBGGR16" and fail in the `configure` step (`Can't configure camera with invalid configuration`).

While it is possible to manually set a format that does not fail the `configure` step, the possibility that the adjustment selects an invalid configuration without providing any initial configuration may confuse users.

In practice, the `StreamRole::Viewfinder` leads to a better default configuration that is not rejected during the `configure` step. Hence, this PR mainly changes the default `role` to reduce automatically adjusted invalid configurations to a minimum. Also, clean up the terminal output and provide more details about failures for debugging.