### PR TITLE
bump the minor version for a new release

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>camera_ros</name>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <description>node for libcamera supported cameras (V4L2, Raspberry Pi Camera Modules)</description>
   <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
Bump the version to prepare a new release with support for libcamera 0.4 and fixes and documentation for the Raspberry Pi Camera Modules.