### PR TITLE
update build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ mkdir -p ~/camera_ws/src
 cd ~/camera_ws/src
 
 # check out libcamera
+sudo apt -y install python3-colcon-meson
 # Option A: official upstream
 git clone https://git.libcamera.org/libcamera/libcamera.git
 # Option B: raspberrypi fork with support for newer camera modules

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ git clone https://github.com/christianrauch/camera_ros.git
 # resolve binary dependencies and build workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd ~/camera_ws/
-rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO --skip-keys=libcamera
+rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO --skip-keys=libcamera
 colcon build --event-handlers=console_direct+
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone https://github.com/christianrauch/camera_ros.git
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd ~/camera_ws/
 rosdep install --from-paths src --ignore-src --skip-keys=libcamera
-colcon build
+colcon build --event-handlers=console_direct+
 ```
 
 If you are using a binary distribution of libcamera, you can skip adding this to the workspace. Additionally, if you want to use the bloomed libcamera package in the ROS repos, you can also omit `--skip-keys=libcamera` and have this binary dependency resolved automatically.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ git clone https://github.com/christianrauch/camera_ros.git
 # resolve binary dependencies and build workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd ~/camera_ws/
-rosdep install --from-paths src --ignore-src --skip-keys=libcamera
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO --skip-keys=libcamera
 colcon build --event-handlers=console_direct+
 ```
 


### PR DESCRIPTION
Tweak the build documentation to cover cases where `camera_ros` is built on a fresh system without any previously installed ROS packages.