### PR TITLE
refine exceptions

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -504,13 +504,14 @@ CameraNode::declareParameters()
     rclcpp::ParameterType pv_type;
     try {
       pv_type = cv_to_pv_type(id);
-      if (pv_type == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-        RCLCPP_WARN_STREAM(get_logger(), "unsupported control '" << id->name() << "'");
-        continue;
-      }
     }
-    catch (const std::runtime_error &e) {
-      // ignore
+    catch (const unknown_control &e) {
+      // ignore not yet handled control
+      RCLCPP_WARN_STREAM(get_logger(), e.what());
+      continue;
+    }
+    catch (const unsupported_control &e) {
+      // ignore control which cannot be supported
       RCLCPP_WARN_STREAM(get_logger(), e.what());
       continue;
     }
@@ -528,7 +529,7 @@ CameraNode::declareParameters()
         "}..{" + info.max().toString() + "}" +
         (info.def().isNone() ? std::string {} : " (default: {" + info.def().toString() + "})");
     }
-    catch (const std::runtime_error &e) {
+    catch (const unknown_control &e) {
       // ignore
       RCLCPP_WARN_STREAM(get_logger(), e.what());
       continue;

--- a/src/clamp.cpp
+++ b/src/clamp.cpp
@@ -1,3 +1,4 @@
+#include "exceptions.hpp"
 #include "libcamera_version_utils.hpp"
 #include "types.hpp"
 #include <algorithm>
@@ -313,7 +314,7 @@ operator<(const libcamera::ControlValue &lhs, const libcamera::ControlValue &rhs
 #endif
   }
 
-  throw std::runtime_error("unhandled control type " + std::to_string(lhs.type()));
+  throw should_not_reach();
 }
 
 bool
@@ -339,5 +340,5 @@ operator>(const libcamera::ControlValue &lhs, const libcamera::ControlValue &rhs
 #endif
   }
 
-  throw std::runtime_error("unhandled control type " + std::to_string(lhs.type()));
+  throw should_not_reach();
 }

--- a/src/clamp.cpp
+++ b/src/clamp.cpp
@@ -141,7 +141,7 @@ clamp(const libcamera::ControlValue &value, const libcamera::ControlValue &min,
       const libcamera::ControlValue &max)
 {
   if (min.type() != max.type())
-    throw std::runtime_error("minimum (" + std::to_string(min.type()) + ") and maximum (" +
+    throw invalid_conversion("minimum (" + std::to_string(min.type()) + ") and maximum (" +
                              std::to_string(max.type()) + ") types mismatch");
 
   switch (value.type()) {

--- a/src/cv_to_pv.cpp
+++ b/src/cv_to_pv.cpp
@@ -140,7 +140,7 @@ cv_to_pv_type(const libcamera::ControlId *const id)
   if (get_extent(id) == 0) {
     switch (id->type()) {
     case libcamera::ControlType::ControlTypeNone:
-      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+      throw unsupported_control(id);
     case libcamera::ControlType::ControlTypeBool:
       return rclcpp::ParameterType::PARAMETER_BOOL;
     case libcamera::ControlType::ControlTypeByte:
@@ -168,7 +168,7 @@ cv_to_pv_type(const libcamera::ControlId *const id)
   else {
     switch (id->type()) {
     case libcamera::ControlType::ControlTypeNone:
-      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+      throw unsupported_control(id);
     case libcamera::ControlType::ControlTypeBool:
       return rclcpp::ParameterType::PARAMETER_BOOL_ARRAY;
     case libcamera::ControlType::ControlTypeByte:
@@ -184,15 +184,15 @@ cv_to_pv_type(const libcamera::ControlId *const id)
     case libcamera::ControlType::ControlTypeString:
       return rclcpp::ParameterType::PARAMETER_STRING_ARRAY;
     case libcamera::ControlType::ControlTypeRectangle:
-      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+      throw unsupported_control(id);
     case libcamera::ControlType::ControlTypeSize:
-      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+      throw unsupported_control(id);
 #if LIBCAMERA_VER_GE(0, 4, 0)
     case libcamera::ControlType::ControlTypePoint:
-      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+      throw unsupported_control(id);
 #endif
     }
   }
 
-  return rclcpp::ParameterType::PARAMETER_NOT_SET;
+  throw should_not_reach();
 }

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <libcamera/controls.h>
 #include <stdexcept>
 
 
@@ -12,4 +13,16 @@ class should_not_reach : public std::runtime_error
 {
 public:
   explicit should_not_reach() : std::runtime_error("should not reach here") {}
+};
+
+class unknown_control : public std::runtime_error
+{
+public:
+  explicit unknown_control(const libcamera::ControlId *const id) : std::runtime_error("unknown control: " + id->name() + " (" + std::to_string(id->id()) + ")") {}
+};
+
+class unsupported_control : public std::runtime_error
+{
+public:
+  explicit unsupported_control(const libcamera::ControlId *const id) : std::runtime_error("unsupported control: " + id->name() + " (" + std::to_string(id->id()) + ")") {}
 };

--- a/src/type_extent.cpp
+++ b/src/type_extent.cpp
@@ -1,4 +1,5 @@
 #include "type_extent.hpp"
+#include "exceptions.hpp"
 #include "libcamera_version_utils.hpp"
 #include <libcamera/base/span.h>
 #include <libcamera/control_ids.h>
@@ -85,6 +86,5 @@ get_extent(const libcamera::ControlId *const id)
 #endif
 #endif
 
-  throw std::runtime_error("control " + id->name() + " (" + std::to_string(id->id()) +
-                           ") not handled");
+  throw unknown_control(id);
 }


### PR DESCRIPTION
Refine the exception handling by replacing `std::runtime_error` with one of the specialised exceptions.