### PR TITLE
Add array bounds check in pv_to_cv_int_array

### DIFF
--- a/src/pv_to_cv.cpp
+++ b/src/pv_to_cv.cpp
@@ -46,11 +46,20 @@ pv_to_cv_int_array(const std::vector<int64_t> &values, const libcamera::ControlT
     CASE_CONVERT_INT_ARRAY(Float)
     CASE_INVALID(String)
   case libcamera::ControlTypeRectangle:
+    if (values.size() != 4)
+      throw invalid_conversion("integer array size must be equal to 4 for Rectangle conversion");
+
     return libcamera::Rectangle(values[0], values[1], values[2], values[3]);
   case libcamera::ControlTypeSize:
+    if (values.size() != 2)
+      throw invalid_conversion("integer array size must be equal to 2 for Size conversion");
+
     return libcamera::Size(values[0], values[1]);
 #if LIBCAMERA_VER_GE(0, 4, 0)
   case libcamera::ControlTypePoint:
+    if (values.size() != 2)
+      throw invalid_conversion("integer array size must be equal to 2 for Point conversion");
+
     return libcamera::Point(values[0], values[1]);
 #endif
   }


### PR DESCRIPTION
Hello, I recently made some changes to `camera_ros` and I wanted to contribute them to upstream.
This pull request is the first in a series of three. This one aims to fix two small issues.

Firstly, it adds four new controls to the `get_extent` function, namely: `NoiseReductionMode`, `CnnEnableInputTensor`, `SyncMode`, and `SyncFrames`.

I noticed that there were warnings associated with these controls when using the Raspberry Pi Camera V3 alongside Raspberry Pi's `libcamera` fork. `NoiseReductionMode` is available in the `draft` control ids of upstream `libcamera`, but `CnnEnableInputTensor`, `SyncMode`, and `SyncFrames` are only available in the Raspberry Pi fork, so they're only enabled when `RASPBERRY_PI_LIBCAMERA` is defined. `RASPBERRY_PI_LIBCAMERA` has to be defined manually using a CMake flag, when using Raspberry Pi's fork (`-DCMAKE_CXX_FLAGS="-DRASPBERRY_PI_LIBCAMERA"`). Leaving it undefined does not result in errors, of course.

The warnings in question, for reference:
```
[WARN] [1739245374.975255267] [camera]: unknown control: SyncFrames (20014)
...
[WARN] [1739245374.975602615] [camera]: unknown control: CnnEnableInputTensor (20007)
[WARN] [1739245374.975727373] [camera]: unknown control: SyncMode (20011)
[WARN] [1739245374.975805372] [camera]: unknown control: NoiseReductionMode (10002)
```
<br>

Secondly, it adds array length checks to `pv_to_cv_int_array` in `pv_to_cv.cpp` for the `Rectangle`, `Point`, and `Size` conversions. This is important because it is possible to pass an int array parameter with a length less than the length required for a given conversion, which would result in out-of-bounds array access and undefined behavior.

I'm not sure about the contribution policies of this project, or even if you accept pull requests.
If it's alright with you, I would like to open the other two pull requests as well. One of them adds a new parameter for setting the URL of the camera calibration info file, and the other adds support for nested-array-type controls such as `Af-Windows` (array of `Rectangle`s).

And apologies for the pull request I opened earlier; that was a mistake.