### PR TITLE
Ensure fixed-extent span controls with None defaults aren't skipped

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -516,7 +516,7 @@ CameraNode::declareParameters()
     const bool ctrl_dynamic = (extent == libcamera::dynamic_extent);
     const bool ctrl_fixed = !(ctrl_scalar || ctrl_dynamic);
 
-    if (ctrl_fixed && !info.def().isArray()) {
+    if (ctrl_fixed && !info.def().isArray() && !info.def().isNone()) {
       RCLCPP_WARN_STREAM(get_logger(),
                          id->name() << ": cannot set default scalar value "
                                     << "on span control (extend: " << extent << ")");


### PR DESCRIPTION
Sorry for opening so many PRs...
This is just a small fix for an issue I noticed when testing `camera_ros` just now.

The new check for making sure scalar defaults aren't set for fixed-extent span controls is also causing some controls with `None` defaults to be skipped.

For example, `FrameDurationLimits` is a span with fixed extent but its default value is `None` (_at least in my case_), and therefore scalar. `None` default values are handled by the program later on, so the entire control shouldn't be skipped.