### PR TITLE
Consider control extent when clamping control values

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -580,7 +580,7 @@ CameraNode::declareParameters()
     // clamp default ControlValue to min/max range and cast ParameterValue
     rclcpp::ParameterValue value;
     try {
-      value = cv_to_pv(clamp(info.def(), info.min(), info.max()));
+      value = cv_to_pv(clamp(info.def(), info.min(), info.max(), extent));
     }
     catch (const invalid_conversion &e) {
       RCLCPP_ERROR_STREAM(get_logger(), "unsupported control '"

--- a/src/clamp.hpp
+++ b/src/clamp.hpp
@@ -13,7 +13,7 @@ max(const libcamera::ControlValue &value);
 
 libcamera::ControlValue
 clamp(const libcamera::ControlValue &value, const libcamera::ControlValue &min,
-      const libcamera::ControlValue &max);
+      const libcamera::ControlValue &max, size_t extent);
 
 bool
 operator<(const libcamera::ControlValue &a, const libcamera::ControlValue &b);


### PR DESCRIPTION
I've extracted the `clamp` fix from my other PR. As I mentioned there:

> I also had to make some minor modifications to the `clamp` and `clamp_array` functions. This is because there can be cases in which _scalar_ `min`, `max`, and `default` values for a _span_ control are passed to `clamp`. In such cases, `clamp` would return a scalar value, which would then be set as the default for the aforementioned _span_ control (in `CameraNode::declare_parameters()`). This exact scenario occurs with `AfWindows`. `AfWindows` is a span type, but its `min`, `max`, and `default` values are scalar. 
>
> _(Note: when referring to span controls above, I'm referring to dynamic ones, not fixed-length ones)_
>
> I fixed this issue by passing the extent of the control to `clamp` and using that to determine whether the control is scalar or not instead of using `value.isArray()`. If the control has dynamic extent, a span `ControlValue` with one element (clamped `value`) is returned.

More clearly: libcamera (at least the RPi fork, as that's what I'm testing with) sometimes provides scalar default values for span controls. In those cases, the current `clamp()` also returns a scalar value which is then set as the default for that control. However, I thought it might be better (for controls with dynamic extent) for `clamp` to return a span with a single element (clamped scalar default) instead of just returning a scalar value.

To achieve this, I did have to make it so that the extent of the control is also passed to `clamp`, which might not be desirable; but given that `clamp` is only used when setting default control values, I don't think this is going to be an issue.