### PR TITLE
assume enabled for unset auto exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug
 ```
 and then run the node with libcamera and ROS debug information in `gdb`:
 ```sh
-LIBCAMERA_LOG_LEVELS=*:DEBUG ros2 run --prefix 'gdb -ex run --args' camera_ros camera_node --ros-args --log-level debug -p width:=640 -p height:=480
+LIBCAMERA_LOG_LEVELS=*:DEBUG ros2 run --prefix 'gdb -ex run --args' camera_ros camera_node --ros-args --log-level camera:=debug -p width:=640 -p height:=480
 ```
 
 

--- a/src/parameter_conflict_check.cpp
+++ b/src/parameter_conflict_check.cpp
@@ -12,9 +12,15 @@ resolve_conflicts(const ParameterMap &parameters_default, const ParameterMap &pa
   // auto exposure (AeEnable) and manual exposure (ExposureTime)
   // must not be enabled at the same time
 
+  // assume enabled for unset auto exposure (AeEnable)
+  if (parameters_init.count("AeEnable") &&
+      (parameters_init.at("AeEnable").get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET))
+  {
+    parameters_init.at("AeEnable") = rclcpp::ParameterValue {true};
+  }
+
   // default: prefer auto exposure
   if (parameters_init.count("AeEnable") &&
-      (parameters_init.at("AeEnable").get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) &&
       parameters_init.at("AeEnable").get<bool>() &&
       parameters_init.count("ExposureTime"))
   {


### PR DESCRIPTION
If control `AeEnable` does not have a default value, we would assume that it is "off", setting the `ExposureTime` by default. If the default `ExposureTime` is low, this leads to underexposed images by default.

Fix this by assuming that `AeEnable` is always explicitly disabled and assume enabled by default.