### PR TITLE
Fix regression by adding missing dependencies: gtest_vendor and ament…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 find_package(PkgConfig REQUIRED)
 
 # find dependencies
+find_package(gtest_vendor REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,9 @@
   <depend>sensor_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>cv_bridge</depend>
+  <depend>ament_cmake_ros</depend>
+  <depend>gtest_vendor</depend>
+
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>


### PR DESCRIPTION
This PR fixes [#109](https://github.com/christianrauch/camera_ros/issues/109) by adding missing dependencies to resolve the regression blocking builds in Rolling.

Changes:
- Added `gtest_vendor` and `ament_cmake_ros` to `CMakeLists.txt`
- Added corresponding `<depend>` tags in `package.xml`
