### PR TITLE
Add Camera frame_id Parameter to Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The camera stream is configured once when the node starts via the following stat
 | `sensor_mode`     | `string`              | desired raw sensor format resolution (format: `width:height`) [default: auto]                                               |
 | `orientation`     | `integer`             | camera orientation in 90 degree steps (possible choices: `0`, `90`, `180`, `270`) [default: `0`]                            |
 | `camera_info_url` | `string`              | URL for a camera calibration YAML file (see [Calibration](#calibration)) [default: `~/.ros/camera_info/$NAME.yaml`]         |
+| `frame_id`        | `string`              | frame_id of the camera frame used in the header of the image messages                                                       |
 
 
 The configuration is done in the following order:

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -105,6 +105,7 @@ private:
   camera_info_manager::CameraInfoManager cim;
 
   ParameterHandler parameter_handler;
+  std::string frame_id;
 
 #ifdef RCLCPP_HAS_PARAM_EXT_CB
   // use new "post_set" callback to apply parameters
@@ -258,6 +259,9 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options)
   param_descr_sensor_mode.additional_constraints = "string in format [width]:[height]";
   param_descr_sensor_mode.read_only = true;
   const libcamera::Size sensor_size = get_sensor_format(declare_parameter<std::string>("sensor_mode", {}, param_descr_sensor_mode));
+
+  // camera frame_id
+  frame_id = declare_parameter<std::string>("frame_id", "camera", param_descr_ro);
 
 #if LIBCAMERA_VER_GE(0, 2, 0)
   rcl_interfaces::msg::ParameterDescriptor param_descr_orientation;
@@ -617,7 +621,7 @@ CameraNode::process(libcamera::Request *const request)
       // send image data
       std_msgs::msg::Header hdr;
       hdr.stamp = rclcpp::Time(time_offset + int64_t(metadata.timestamp));
-      hdr.frame_id = "camera";
+      hdr.frame_id = frame_id;
       const libcamera::StreamConfiguration &cfg = stream->configuration();
 
       auto msg_img = std::make_unique<sensor_msgs::msg::Image>();


### PR DESCRIPTION
This pull request adds a new parameter, frame_id, to the node to make the frame_id in the messages configurable.

    Updated the node definition to include frame_id.

    Added/updated documentation to reflect the change.

This change makes it possible to use different cameras in different positions on the same robot.