### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,7 @@ add_library(utils OBJECT
   src/pretty_print.cpp
 )
 target_include_directories(utils PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(utils ${libcamera_LINK_LIBRARIES})
-target_link_libraries(utils
+target_link_libraries(utils ${libcamera_LINK_LIBRARIES}
   PUBLIC
   "sensor_msgs"
 )
@@ -48,8 +47,7 @@ add_library(param OBJECT
     src/ParameterConflictHandler.cpp
 )
 target_include_directories(param PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(param ${libcamera_LINK_LIBRARIES})
-target_link_libraries(param
+target_link_libraries(param ${libcamera_LINK_LIBRARIES}
   PUBLIC
   "rclcpp"
 )
@@ -65,9 +63,8 @@ set(PACKAGE_DEPENDENCIES
   "camera_info_manager"
   "cv_bridge"
 )
-target_link_libraries(camera_component PUBLIC ${PACKAGE_DEPENDENCIES})
 target_include_directories(camera_component PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(camera_component PUBLIC ${libcamera_LINK_LIBRARIES})
+target_link_libraries(camera_component PUBLIC ${PACKAGE_DEPENDENCIES} ${libcamera_LINK_LIBRARIES})
 target_link_libraries(camera_component PRIVATE utils param)
 
 ament_export_targets(camera_componentTargets HAS_LIBRARY_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,10 @@ add_library(utils OBJECT
   src/pretty_print.cpp
 )
 target_include_directories(utils PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(utils ${libcamera_LINK_LIBRARIES}
-  PUBLIC
-  "sensor_msgs"
+target_link_libraries(utils PUBLIC
+  ${libcamera_LINK_LIBRARIES}
+  ${sensor_msgs_TARGETS}
+  sensor_msgs::sensor_msgs_library
 )
 set_property(TARGET utils PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -47,9 +48,9 @@ add_library(param OBJECT
     src/ParameterConflictHandler.cpp
 )
 target_include_directories(param PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(param ${libcamera_LINK_LIBRARIES}
-  PUBLIC
-  "rclcpp"
+target_link_libraries(param PUBLIC
+  ${libcamera_LINK_LIBRARIES}
+  rclcpp::rclcpp
 )
 set_property(TARGET param PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -64,7 +65,7 @@ set(PACKAGE_DEPENDENCIES
   "cv_bridge"
 )
 target_include_directories(camera_component PUBLIC ${libcamera_INCLUDE_DIRS})
-target_link_libraries(camera_component PUBLIC ${PACKAGE_DEPENDENCIES} ${libcamera_LINK_LIBRARIES})
+target_link_libraries(camera_component PUBLIC ${libcamera_LINK_LIBRARIES} ${sensor_msgs_TARGETS} camera_info_manager::camera_info_manager cv_bridge::cv_bridge rclcpp::rclcpp rclcpp_components::component rclcpp_components::component_manager sensor_msgs::sensor_msgs_library)
 target_link_libraries(camera_component PRIVATE utils param)
 
 ament_export_targets(camera_componentTargets HAS_LIBRARY_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ add_library(utils OBJECT
 )
 target_include_directories(utils PUBLIC ${libcamera_INCLUDE_DIRS})
 target_link_libraries(utils ${libcamera_LINK_LIBRARIES})
-ament_target_dependencies(
-  utils
+target_link_libraries(utils
+  PUBLIC
   "sensor_msgs"
 )
 set_property(TARGET utils PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -49,8 +49,8 @@ add_library(param OBJECT
 )
 target_include_directories(param PUBLIC ${libcamera_INCLUDE_DIRS})
 target_link_libraries(param ${libcamera_LINK_LIBRARIES})
-ament_target_dependencies(
-  param
+target_link_libraries(param
+  PUBLIC
   "rclcpp"
 )
 set_property(TARGET param PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -65,7 +65,7 @@ set(PACKAGE_DEPENDENCIES
   "camera_info_manager"
   "cv_bridge"
 )
-ament_target_dependencies(camera_component PUBLIC ${PACKAGE_DEPENDENCIES})
+target_link_libraries(camera_component PUBLIC ${PACKAGE_DEPENDENCIES})
 target_include_directories(camera_component PUBLIC ${libcamera_INCLUDE_DIRS})
 target_link_libraries(camera_component PUBLIC ${libcamera_LINK_LIBRARIES})
 target_link_libraries(camera_component PRIVATE utils param)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
