### PR TITLE
only restore 'ExposureTime' if it is not set

### DIFF
--- a/src/ParameterConflictHandler.cpp
+++ b/src/ParameterConflictHandler.cpp
@@ -133,7 +133,8 @@ ParameterConflictHandler::resolve_overrides(ParameterValueMap &p)
   }
   // restore 'ExposureTime'
   if (is_set(p, HAS_ETM ? ETM : AE) &&
-      (HAS_ETM ? (p.at(ETM).get<int32_t>() == ETM_Manual) : !p.at(AE).get<bool>()))
+      (HAS_ETM ? (p.at(ETM).get<int32_t>() == ETM_Manual) : !p.at(AE).get<bool>()) &&
+      !is_set(p, ET) && store.count(ET))
   {
     p.at(ET) = store.at(ET);
     store.erase(ET);


### PR DESCRIPTION
If the `ExposureTimeMode` is `ExposureTimeModeManual` by default, we are not encountering conflicts in the default configuration and hence we do not remove the `ExposureTime` from the default parameter values in `resolve_defaults` and store it. In `resolve_overrides` we only check `ExposureTimeModeManual` to decide if we have to restore the `ExposureTime`
https://github.com/christianrauch/camera_ros/blob/ab763a25646b1c1f87d7856a5c1b732672c13903/src/ParameterConflictHandler.cpp#L134-L140 assuming that if `ExposureTimeModeManual` is `ExposureTimeModeManual`, it was automatically set by the previous conflict check https://github.com/christianrauch/camera_ros/blob/ab763a25646b1c1f87d7856a5c1b732672c13903/src/ParameterConflictHandler.cpp#L124-L133.

This neglects the case where there is no conflict, no default values were adjusted, and no `ExposureTime` was stored before.

Fix this by checking that we do not already have a `ExposureTime`, hence there is no need to restore the value, and that there is actually a stored value to restore.

Fixes #118 .