### PR TITLE
Use modern image_transport API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PACKAGE_DEPENDENCIES
   "sensor_msgs"
   "camera_info_manager"
   "cv_bridge"
+  "image_transport"
 )
 foreach(PKGDEP IN LISTS PACKAGE_DEPENDENCIES)
   find_package(${PKGDEP} REQUIRED)
@@ -79,6 +80,7 @@ target_link_libraries(camera_component PUBLIC
   ${sensor_msgs_TARGETS}
   camera_info_manager::camera_info_manager
   cv_bridge::cv_bridge
+  image_transport::image_transport
 )
 target_include_directories(camera_component PUBLIC ${libcamera_INCLUDE_DIRS})
 target_link_libraries(camera_component PUBLIC ${libcamera_LINK_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>sensor_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>


### PR DESCRIPTION
## Description

This PR updates camera_ros to use the image_transport API, currently tested with ROS 2 Kilted.

The image_transport package takes care of image compression, allowing this PR to be net-negative in lines of code. It also offers an expanded range of alternative transports, such as zstd compression and ffmpeg encoding.

New in the Kilted API is combined "camera" publishers/subscribers, which allows both image and camera info to be processed at the same time in the same function. The new camera API is used in this PR.

## Motivation and contexet

I recently had the need to test custom QoS profiles. I noticed that v4l2_camera recently exposed a way to control the QoS of publishers. It would be valuable if camera_ros could do the same.

v4l2_camera uses the new camera API, so I updated camera_ros likewise, resulting in the diff here. However, I finished my testing before fully exposing the publisher's QoS. Still, this change allows v4l2_camera-style QoS configuration in the future.

## How has this been tested?

I'm currently running this patch on my robotic Millennium Falcon, along with image rectification. The new transport topics successfully show up:

```
# ros2 topic list
/oasis/falcon/camera_info
/oasis/falcon/image_raw
/oasis/falcon/image_raw/compressed
/oasis/falcon/image_raw/compressedDepth
/oasis/falcon/image_raw/ffmpeg
/oasis/falcon/image_raw/theora
/oasis/falcon/image_raw/zstd
/oasis/falcon/image_rect
/oasis/falcon/image_rect/compressed
/oasis/falcon/image_rect/compressedDepth
/oasis/falcon/image_rect/ffmpeg
/oasis/falcon/image_rect/theora
/oasis/falcon/image_rect/zstd
```

Downstream, I'm using ORB_SLAM3 on the `image_raw` topic and apriltag_ros on the `image_rect` topic for robot pose estimation, control and visualization.