### PR TITLE
use global shared camera manager

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -72,10 +72,6 @@ class NodeOptions;
 namespace camera
 {
 
-// Global shared pointer to the camera manager
-static std::weak_ptr<libcamera::CameraManager> g_camera_manager;
-static std::mutex g_camera_manager_mutex;
-
 class CameraNode : public rclcpp::Node
 {
 public:
@@ -84,6 +80,9 @@ public:
   ~CameraNode();
 
 private:
+  static std::weak_ptr<libcamera::CameraManager> g_camera_manager;
+  static std::mutex g_camera_manager_mutex;
+
   std::shared_ptr<libcamera::CameraManager> camera_manager;
   std::shared_ptr<libcamera::Camera> camera;
   libcamera::Stream *stream;
@@ -621,7 +620,6 @@ CameraNode::~CameraNode()
   allocator.reset();
   camera->release();
   camera.reset();
-  // camera_manager->stop(); // Handled by shared_ptr deleter
   for (const auto &e : buffer_info)
     if (munmap(e.second.data, e.second.size) == -1)
       std::cerr << "munmap failed: " << std::strerror(errno) << std::endl;

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -342,7 +342,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options)
     camera_manager = g_camera_manager.lock();
     if (!camera_manager) {
       camera_manager = std::shared_ptr<libcamera::CameraManager>(
-        new libcamera::CameraManager, [](auto * p) {
+        new libcamera::CameraManager, [](auto *p) {
           p->stop();
           delete p;
         });

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -768,3 +768,6 @@ CameraNode::onParameterChange(const std::vector<rclcpp::Parameter> &parameters)
 #endif
 
 } // namespace camera
+
+std::weak_ptr<libcamera::CameraManager> camera::CameraNode::g_camera_manager;
+std::mutex camera::CameraNode::g_camera_manager_mutex;


### PR DESCRIPTION
I was having the same problem described here: https://github.com/christianrauch/camera_ros/issues/113 while trying to load multiple camera drivers (as Composable Nodes) into the same ROS 2 Container.

This is especially useful to optimize resources and guarantee zero-copy transmission from the nodes in the same container.
<img width="1920" height="1080" alt="ROS2 container" src="https://github.com/user-attachments/assets/b8ad4431-75b8-449d-9a6d-42f91b0ae638" />

This PR fixes the error

> [0:15:23.264404928] [1855] FATAL Camera camera_manager.cpp:310 Multiple CameraManager objects are not allowed

by having a global, shared CameraManager object.

To reproduce the issue:

1. Start a new ROS 2 Container
`ros2 run rclcpp_components component_container`
2. Load the first CameraNode inside the container to connect to the right camera
`ros2 component load /ComponentManager camera_ros camera::CameraNode --parameter camera:=1 --parameter frame_id:=right_camera --node-namespace /right`
3. Load the second CameraNode in the same container to connect to the left camera
`ros2 component load /ComponentManager camera_ros camera::CameraNode --parameter camera:=0 --parameter frame_id:=left_camera --node-namespace /left`