### PR TITLE
publish device and frame metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PACKAGE_DEPENDENCIES
   "rclcpp"
   "rclcpp_components"
   "sensor_msgs"
+  "diagnostic_msgs"
   "camera_info_manager"
   "cv_bridge"
 )
@@ -77,6 +78,7 @@ target_link_libraries(camera_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
   ${sensor_msgs_TARGETS}
+  ${diagnostic_msgs_TARGETS}
   camera_info_manager::camera_info_manager
   cv_bridge::cv_bridge
 )

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>cv_bridge</depend>
 

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -642,6 +642,25 @@ CameraNode::process(libcamera::Request *const request)
     if (!running)
       return;
 
+    // prepare message header
+    std_msgs::msg::Header hdr;
+    hdr.frame_id = frame_id;
+
+    // if using sensor timestamps, get the sensor timestamp from the request metadata
+    int64_t sensor_latency = 0;
+    if (!use_node_time) {
+      const libcamera::ControlList &req_metadata = request->metadata();
+      if (const std::optional<int64_t> sensor_ts = req_metadata.get(libcamera::controls::SensorTimestamp)) {
+        sensor_latency = rclcpp::Clock(RCL_STEADY_TIME).now().nanoseconds() - sensor_ts.value();
+      }
+      else {
+        RCLCPP_WARN_STREAM_ONCE(get_logger(), "sensor timestamp not available, falling back to node time as reference");
+      }
+    }
+
+    // Adjust timestamp by the sensor latency
+    hdr.stamp = this->now() - rclcpp::Duration::from_nanoseconds(sensor_latency);
+
     if (request->status() == libcamera::Request::RequestComplete) {
       assert(request->buffers().size() == 1);
 
@@ -651,25 +670,6 @@ CameraNode::process(libcamera::Request *const request)
       size_t bytesused = 0;
       for (const libcamera::FrameMetadata::Plane &plane : metadata.planes())
         bytesused += plane.bytesused;
-
-      // prepare message header
-      std_msgs::msg::Header hdr;
-      hdr.frame_id = frame_id;
-
-      // if using sensor timestamps, get the sensor timestamp from the request metadata
-      int64_t sensor_latency = 0;
-      if (!use_node_time) {
-        const libcamera::ControlList &req_metadata = request->metadata();
-        if (const std::optional<int64_t> sensor_ts = req_metadata.get(libcamera::controls::SensorTimestamp)) {
-          sensor_latency = rclcpp::Clock(RCL_STEADY_TIME).now().nanoseconds() - sensor_ts.value();
-        }
-        else {
-          RCLCPP_WARN_STREAM_ONCE(get_logger(), "sensor timestamp not available, falling back to node time as reference");
-        }
-      }
-
-      // Adjust timestamp by the sensor latency
-      hdr.stamp = this->now() - rclcpp::Duration::from_nanoseconds(sensor_latency);
 
       // prepare image messages
       const libcamera::StreamConfiguration &cfg = stream->configuration();

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -15,6 +15,7 @@
 #include <cv_bridge/cv_bridge.h>
 #endif
 #include <atomic>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <iostream>
 #include <libcamera/base/shared_fd.h>
 #include <libcamera/base/signal.h>
@@ -100,6 +101,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_image;
   rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr pub_image_compressed;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pub_ci;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics;
 
   camera_info_manager::CameraInfoManager cim;
 
@@ -329,6 +331,8 @@ CameraNode::CameraNode(const rclcpp::NodeOptions &options)
   pub_image_compressed =
     this->create_publisher<sensor_msgs::msg::CompressedImage>("~/image_raw/compressed", 1);
   pub_ci = this->create_publisher<sensor_msgs::msg::CameraInfo>("~/camera_info", 1);
+  pub_diagnostics =
+    this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
 
   // start camera manager and check for cameras
   const int ec_start = camera_manager.start();
@@ -661,8 +665,23 @@ CameraNode::process(libcamera::Request *const request)
     // Adjust timestamp by the sensor latency
     hdr.stamp = this->now() - rclcpp::Duration::from_nanoseconds(sensor_latency);
 
+    diagnostic_msgs::msg::DiagnosticArray diagnostic_array;
+    diagnostic_array.header = hdr;
+
+    diagnostic_msgs::msg::DiagnosticStatus diagnostic_status;
+    diagnostic_status.hardware_id = camera->id();
+
     if (request->status() == libcamera::Request::RequestComplete) {
       assert(request->buffers().size() == 1);
+
+      diagnostic_status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+      for (const auto &[id, value] : request->metadata()) {
+        diagnostic_msgs::msg::KeyValue kv;
+        kv.key = libcamera::controls::controls.at(id)->name();
+        kv.value = value.toString();
+        diagnostic_status.values.push_back(kv);
+      }
 
       // get the stream and buffer from the request
       const libcamera::FrameBuffer *buffer = request->findBuffer(stream);
@@ -725,8 +744,13 @@ CameraNode::process(libcamera::Request *const request)
       pub_ci->publish(ci);
     }
     else if (request->status() == libcamera::Request::RequestCancelled) {
+      diagnostic_status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       RCLCPP_ERROR_STREAM(get_logger(), "request '" << request->toString() << "' cancelled");
     }
+
+    diagnostic_array.status.push_back(diagnostic_status);
+
+    pub_diagnostics->publish(diagnostic_array);
 
     // redeclare implicitly undeclared parameters
     parameter_handler.redeclare();

--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -676,7 +676,11 @@ CameraNode::process(libcamera::Request *const request)
 
       diagnostic_status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
-      for (const auto &[id, value] : request->metadata()) {
+      // publish metadata, sorted by control ID
+      for (const auto &[id, value] : std::map {
+             request->metadata().begin(),
+             request->metadata().end(),
+           }) {
         diagnostic_msgs::msg::KeyValue kv;
         kv.key = libcamera::controls::controls.at(id)->name();
         kv.value = value.toString();


### PR DESCRIPTION
This publishes metadata on the `/diagnostics` topic.

For a "Raspberry Pi Camera Module 3 Wide" (`imx708_wide`):
```yaml
header:
  stamp:
    sec: 1775986969
    nanosec: 205131369
  frame_id: camera
status:
- level: "\0"
  name: ''
  message: ''
  hardware_id: /base/axi/pcie@120000/rp1/i2c@88000/imx708@1a
  values:
  - key: AeState
    value: '2'
  - key: ExposureTime
    value: '29984'
  - key: AnalogueGain
    value: '1.896296'
  - key: Lux
    value: '264.828186'
  - key: ColourGains
    value: '[ 1.639470, 2.348040 ]'
  - key: ColourTemperature
    value: '3192'
  - key: SensorBlackLevels
    value: '[ 4096, 4096, 4096, 4096 ]'
  - key: FocusFoM
    value: '604'
  - key: ColourCorrectionMatrix
    value: '[ 1.692690, -0.428783, -0.263911, -0.369412, 1.733128, -0.363710, 0.084634, -0.924698, 1.840067 ]'
  - key: ScalerCrop
    value: (768, 432)/2304x1728
  - key: DigitalGain
    value: '1.000697'
  - key: FrameDuration
    value: '33327'
  - key: SensorTemperature
    value: '40.000000'
  - key: SensorTimestamp
    value: '2492886965000'
  - key: LensPosition
    value: '1.000000'
  - key: AfState
    value: '0'
  - key: AfPauseState
    value: '0'
  - key: FrameWallClock
    value: '1775986969205125632'
```

Fixes #165 .