### PR TITLE
synchronise control values of queued request to parameter store

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -770,6 +770,10 @@ CameraNode::process(libcamera::Request *const request)
     if (const int ret = camera->queueRequest(request); ret < 0) {
       RCLCPP_WARN_STREAM(get_logger(), "failed to queue request (" << request->toString() << "): " << strerror(-ret));
     }
+
+    if (!parameter_handler.sync_control_values(request->controls())) {
+      RCLCPP_WARN_STREAM(get_logger(), "Failed to synchronise control values of queued request!");
+    }
   }
 }
 

--- a/src/ParameterConflictHandler.cpp
+++ b/src/ParameterConflictHandler.cpp
@@ -87,10 +87,6 @@ is_set(const ParameterConflictHandler::ParameterValueMap &p,
   return p.count(name) && (p.at(name).get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET);
 }
 
-ParameterConflictHandler::ParameterConflictHandler()
-{
-}
-
 std::vector<std::string>
 ParameterConflictHandler::resolve_defaults(ParameterValueMap &p)
 {

--- a/src/ParameterConflictHandler.hpp
+++ b/src/ParameterConflictHandler.hpp
@@ -11,8 +11,6 @@ class ParameterConflictHandler
 public:
   typedef std::unordered_map<std::string, rclcpp::ParameterValue> ParameterValueMap;
 
-  ParameterConflictHandler();
-
   std::vector<std::string>
   resolve_defaults(ParameterValueMap &p);
 

--- a/src/ParameterHandler.cpp
+++ b/src/ParameterHandler.cpp
@@ -273,6 +273,13 @@ ParameterHandler::redeclare()
 void
 ParameterHandler::PreSetResolve(std::vector<rclcpp::Parameter> &parameters)
 {
+  // If an empty parameter list is set, only the "pre_set_parameters" callback
+  // will be called. This invalidates assumptions about how the order of parameter
+  // callbacks (pre_set -> on_set -> post_set) manipulate the internal state.
+  // Skip the "pre_set_parameters" callback when no parameters are provided.
+  if (parameters.empty())
+    return;
+
   parameter_conflict_handler.restore(parameters);
 }
 

--- a/src/ParameterHandler.cpp
+++ b/src/ParameterHandler.cpp
@@ -229,6 +229,33 @@ ParameterHandler::move_control_values(libcamera::ControlList &controls)
   control_values.clear();
 }
 
+bool
+ParameterHandler::sync_control_values(const libcamera::ControlList &controls)
+{
+  if (controls.empty())
+    return true;
+
+  // set ROS parameters to synchronise control values to internal parameter store
+
+  std::vector<rclcpp::Parameter> parameters_list;
+  for (const auto &[id, value] : controls) {
+    const std::string &name = libcamera::controls::controls.at(id)->name();
+    if (camera_controls.count(name)) {
+      parameters_list.push_back({name, cv_to_pv(value)});
+    }
+  }
+
+  const rcl_interfaces::msg::SetParametersResult param_set_result =
+    node->set_parameters_atomically(parameters_list);
+
+  // clear control values that have been set by the callbacks
+  control_values_lock.lock();
+  control_values.clear();
+  control_values_lock.unlock();
+
+  return param_set_result.successful;
+}
+
 void
 ParameterHandler::redeclare()
 {

--- a/src/ParameterHandler.hpp
+++ b/src/ParameterHandler.hpp
@@ -30,6 +30,9 @@ public:
   void
   move_control_values(libcamera::ControlList &controls);
 
+  bool
+  sync_control_values(const libcamera::ControlList &controls);
+
   void
   redeclare();
 


### PR DESCRIPTION
Since libcamera 0.5.2, 'Camera::patchControlList' is used to apply manual
updates to the request controls when 'Camera::queueRequest' is called. This
is currently used to set 'ExposureTimeMode' and 'AnalogueGainMode' when
'AeEnable' is set.

Previously, this would lead to asynchronous states, as setting `AeEnable`
changes the internal control values which would not be reflected in the
parameters of the node.

Fix this by manually setting the ROS parameters from the request controls
after a request is queued.
